### PR TITLE
Validate the HTML, not just links

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ dist: trusty
 
 install: gem install html-proofer
 
-script: htmlproof
+script: htmlproof --check-html true
 
 branches:
   only:


### PR DESCRIPTION
This should allow us to catch malformed HTML, such as the following:

``` html
<p><p></p></p>
<!-- OR -->
<a><b></a></b>
<!-- OR -->
<a></a></a>
<!-- etc -->
```

  Sorry @threedot14 - didn't realize that this wasn't enabled by default until I realized that we had a duplicate `</div>` in `contacts.html`.
