### PR TITLE
Reorder stylesheet links

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,31 +32,14 @@ clean as possible, so please keep in mind the following rules:
 
 ## How to test
 
-Testing will require you to run a server environment from your computer. This
-is actually really easy and, once set up, can be started in seconds. Below are
-some simple solutions to get you started.
+The easiest way to test is probably through the [Cloud9 IDE](https://c9.io/)
+as it works on Chromebooks as well.  Set up a new workspace and "clone" this
+repository, then `git checkout` the branch that you were working on.  Preview your
+work by selecting the "Preview" button near the top of the page.
+`git commit -am "Commit message here"` to commit your work, and then `git push` to
+update it on Github.  To update, `git pull`.
 
-Python provides an HTTP module that will run a simple HTTP server from the
-current directory. This is started differently depending on what version of
-python you're using.
-
-    $ python2 -m SimpleHTTPServer
-    Serving HTTP on 0.0.0.0 port 8000 ...
-    127.0.0.1 - - [20/Nov/2015 13:52:10] "GET / HTTP/1.1" 200 -
-    (^C to stop)
-    $ python3 -m http.server
-    Serving HTTP on 0.0.0.0 port 8000 ...
-    127.0.0.1 - - [20/Nov/2015 13:54:00] "GET / HTTP/1.1" 200 -
-    (^C to stop)
-
-If you don't have python, [devd](https://github.com/cortesi/devd) is
-a lightweight tool that also provides a simple HTTP server.
-
-    $ devd .
-    13:56:44: Listening on http://devd.io:8000 (127.0.0.1:8000)
-    13:57:00: GET /
-      <- 200 OK 2.8kB
-
-If you're on a device that can't support a test environment, options are
-available for remote environments. [Cloud9 IDE](https://c9.io/) provides an
-online Linux environment that works on most browsers (ex. Chromebooks).
+Alternatively, if you have the HTML and CSS files on your computer already, simply
+double-click the HTML file you want and reload it each time you make a change.  On
+a Chromebook downloading the files is as easy as making sure you're on the correct
+branch and then clicking the "Download ZIP" button on the right-hand side.

--- a/about.html
+++ b/about.html
@@ -4,9 +4,9 @@
         <link href='https://fonts.googleapis.com/css?family=Poiret+One' rel='stylesheet' type='text/css'>
         <meta http-equiv="X-UA-Compatible" content="IE=edge">
         <meta name="viewport" content="width=device-width, initial-scale=1">
-        <link rel="shortcut icon" href="https://img42.com/9zD8L+">
+        <link href="https://img42.com/9zD8L+" rel="shortcut icon">
         <link href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/css/bootstrap.min.css" rel="stylesheet">
-        <link rel="stylesheet" href="/style.css">
+        <link href="style.css" rel="stylesheet">
         <title>About | MHSEC</title>
     </head>
     <body style="background-color: #c7d0d5">

--- a/contact.html
+++ b/contact.html
@@ -4,9 +4,9 @@
         <link href='https://fonts.googleapis.com/css?family=Poiret+One' rel='stylesheet' type='text/css'>
         <meta http-equiv="X-UA-Compatible" content="IE=edge">
         <meta name="viewport" content="width=device-width, initial-scale=1">
-        <link rel="shortcut icon" href="https://img42.com/9zD8L+">
+        <link href="https://img42.com/9zD8L+" rel="shortcut icon">
         <link href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/css/bootstrap.min.css" rel="stylesheet">
-        <link rel="stylesheet" href="/style.css">
+        <link href="style.css" rel="stylesheet">
         <title>Contact | MHSEC</title>
     </head>
     <body style="background-color: #c7d0d5">

--- a/index.html
+++ b/index.html
@@ -4,9 +4,9 @@
         <link href='https://fonts.googleapis.com/css?family=Poiret+One' rel='stylesheet' type='text/css'>
         <meta http-equiv="X-UA-Compatible" content="IE=edge">
         <meta name="viewport" content="width=device-width, initial-scale=1">
-        <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/css/bootstrap.min.css">
-        <link rel="stylesheet" href="/style.css">
-        <link rel="shortcut icon" href="https://img42.com/9zD8L+">
+        <link href="https://img42.com/9zD8L+" rel="shortcut icon">
+        <link href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/css/bootstrap.min.css" rel="stylesheet" >
+        <link href="style.css" rel="stylesheet">
         <title>Home | MHSEC</title>
     </head>
     <body style="background-color: #c7d0d5">

--- a/news.html
+++ b/news.html
@@ -4,9 +4,9 @@
         <link href='https://fonts.googleapis.com/css?family=Poiret+One' rel='stylesheet' type='text/css'>
         <meta http-equiv="X-UA-Compatible" content="IE=edge">
         <meta name="viewport" content="width=device-width, initial-scale=1">
-        <link rel="shortcut icon" href="https://img42.com/9zD8L+">
+        <link href="https://img42.com/9zD8L+" rel="shortcut icon">
         <link href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/css/bootstrap.min.css" rel="stylesheet">
-        <link rel="stylesheet" href="/style.css">
+        <link href="style.css" rel="stylesheet">
         <title>NEWS | MHSEC</title>
     </head>
     <body style="background-color: #c7d0d5">
@@ -24,8 +24,8 @@
             <h1>NEWS</h1>
             <p>Join Colonial Rocketry!</p>
             <p>Engineering Club is starting a rocketry team, and you can be part of it! We will competing in the
-             Team America Rocketry Challenge. Our goal is to design and build a rocket to carry two eggs to an 
-             altitude of 850 feet for about 46 seconds. The Grand Prize winner will receive $100,000! If you are 
+             Team America Rocketry Challenge. Our goal is to design and build a rocket to carry two eggs to an
+             altitude of 850 feet for about 46 seconds. The Grand Prize winner will receive $100,000! If you are
              interested in joining, please email the club. Understand that joining is a commitment.</p>
         </div>
     </body>

--- a/projects.html
+++ b/projects.html
@@ -4,9 +4,9 @@
         <link href='https://fonts.googleapis.com/css?family=Poiret+One' rel='stylesheet' type='text/css'>
         <meta http-equiv="X-UA-Compatible" content="IE=edge">
         <meta name="viewport" content="width=device-width, initial-scale=1">
-        <link rel="shortcut icon" href="https://img42.com/9zD8L+">
+        <link href="https://img42.com/9zD8L+" rel="shortcut icon">
         <link href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/css/bootstrap.min.css" rel="stylesheet">
-        <link rel="stylesheet" href="/style.css">
+        <link href="style.css" rel="stylesheet">
         <title>Projects | MHSEC</title>
     </head>
     <body style="background-color: #c7d0d5">


### PR DESCRIPTION
The order is now `href`, `rel` since the href is arguably the most important part of a link.

This also changes `/style.css` to `style.css` for ease of testing - /cc @threedot14.  With this change it gets loaded correctly when testing locally.  Before it didn't.  Therefore we don't need all the Python mumbo-jumbo.
