### PR TITLE
Update calendar to use google calendar instead of plain text

### DIFF
--- a/schedule.html
+++ b/schedule.html
@@ -25,14 +25,9 @@
         <h1>OUR SCHEDULE</h1>
         <h2>Here you can see the dates of upcoming Engineering Club meetings.</h2>
         
-         <div class="post infobox">
-            <h2 class="post-title">Schedule from October to December</h2>
-            <span class="post-date">October 24, 2016</span>
-            <p>The Upcoming dates for the Engineering club are mostly alternating Fridays starting this Friday. The dates we will meet are:</p>
-             <p>10/28</p>
-             <p>11/18</p>
-             <p>12/09</p>
-        </div>
+         <div>
+           <iframe src="https://calendar.google.com/calendar/embed?height=600&amp;wkst=1&amp;bgcolor=%23ff9900&amp;src=msdk12.net_k8paad2upcjhvddenvcs5ankac%40group.calendar.google.com&amp;color=%2323164E&amp;ctz=America%2FNew_York" style="border-width:0" width="800" height="600" frameborder="0" scrolling="no"></iframe>
+         </div>
         
     </body>
 </html>


### PR DESCRIPTION
Instead of using plain text as a calendar we can use googles calendar service and embed it into the site with a simple HTML tag and it can be managed through calendar.google.com